### PR TITLE
Уточнение зависимостей для безрельсового окружения

### DIFF
--- a/cbrf.gemspec
+++ b/cbrf.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 3.2.1'
   s.add_dependency 'hashie', '>= 3.3.1'
   s.add_dependency 'hpricot', '>= 0.8.6'
+  s.add_dependency 'activesupport', '>= 4.2.0'
 end

--- a/lib/web_parser/cbrf.rb
+++ b/lib/web_parser/cbrf.rb
@@ -1,5 +1,8 @@
 require 'hpricot'
 require 'hashie/mash'
+require 'active_support'
+require 'active_support/core_ext'
+require 'open-uri'
 
 module WebParser
   module Cbrf


### PR DESCRIPTION
При использовании гема вне Rails выдавалась ошибка что у `Fixnum` нет метода `days`, а файл `http://www.cbr.ru` не найден.

Это лечится, явным использованием ActiveSupport и `open-uri`.